### PR TITLE
Downgrade tapestry to 5.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A basic usage example to load an application's Index page and check the page tit
 ### `build.gradle`:
 ```groovy
 repositories {
-  mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 dependencies {
-  testImplementation 'de.eddyson:tapestry-geb:0.45.0'
+  testImplementation "com.github.eddyson-de:tapestry-geb:0.45.2"
   testImplementation "org.seleniumhq.selenium:selenium-firefox-driver:3.141.59"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description = "Utilities for Geb-based browser tests of Tapestry applications"
 
 group = "de.eddyson"
-version = "0.45.1"
+version = "0.45.2"
 
 repositories {
   mavenCentral()
@@ -27,7 +27,7 @@ artifacts {
 }
 
 ext.versions=[
-  tapestry: '5.6.2',
+  tapestry: '5.6.1',
   geb: '4.1',
   spock: '1.3-groovy-2.5',
   selenium: '3.141.59'


### PR DESCRIPTION
5.6.2 is not compatible with most of our other packages.